### PR TITLE
cloud-init: add support for ssh_authorized_keys

### DIFF
--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -73,6 +73,10 @@ sub apply_user_data {
     printf $fh "127.0.1.1 %s %s\n", $shortname, $data->{fqdn};
     close $fh;
   }
+
+  if (defined($data->{ssh_authorized_keys})) {
+    install_pubkeys join("\n", @{ $data->{ssh_authorized_keys} });
+  }
 }
 
 sub cloud_init {


### PR DESCRIPTION
It can be used to append more keys. Example:

    #cloud-config
    ssh_authorized_keys:
      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAACCCuPKlu22nwrDxwiqAvrFbPdSIRq02g2PDGrLwMy299 alfred@batman