### PR TITLE
use correct meta-data path for request

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ directory structure:
 
 ```
 ./cloud-init.pl => this script
-./latest/public-keys => "ssh-rsa ..." (your pubkey)
+./latest/meta-data/public-keys => "ssh-rsa ..." (your pubkey)
 ./latest/user-data => "#cloud-config\nfqdn: some.host.name\nmanage_etc_hosts: true\n"
 ```
 

--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -28,9 +28,9 @@ use File::Temp qw(tempfile);
 
 use strict;
 
-sub get_metadata {
-  my ($host, $type) = @_;
-  my $response = HTTP::Tiny->new->get("http://$host/latest/$type");
+sub get_data {
+  my ($host, $path) = @_;
+  my $response = HTTP::Tiny->new->get("http://$host/latest/$path");
   return unless $response->{success};
   return $response->{content};
 }
@@ -81,9 +81,9 @@ sub apply_user_data {
 
 sub cloud_init {
     my $host = get_host();
-    my $data = get_metadata($host, 'user-data');
+    my $data = get_data($host, 'user-data');
 
-    my $pubkeys = get_metadata($host, 'public-keys');
+    my $pubkeys = get_data($host, 'meta-data/public-keys');
     chomp($pubkeys);
     install_pubkeys $pubkeys;
 


### PR DESCRIPTION
Change the path for meta-data to match with the latest URL used by the virtual router in CloudStack.