### PR TITLE
cloud-init: add support for packages and runcmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ as possible by default. The following actions are currently supported:
 - Persistent hostname personalization if requested.
 - Local host resolution personalization if requested.
 - Optional custom script execution.
+- Packages installation (pkg_add) support.
+- Custom commands (runcmd) execution.
 
 ## Future improvements
 
 - [ ] Root disk resize
 - [ ] Cloud-init user and group creation support
 - [ ] Cloud-init write-file support
-- [ ] Cloud-init pkg_add configuration support
 - [ ] Cloud-init custom package install support
 - [ ] Cloud-init puppet initialization support
 - [ ] Cloud-init resolv.conf personalization support

--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -78,6 +78,18 @@ sub apply_user_data {
   if (defined($data->{ssh_authorized_keys})) {
     install_pubkeys join("\n", @{ $data->{ssh_authorized_keys} });
   }
+
+  if (defined($data->{packages})) {
+    foreach my $package (@{ $data->{packages} }) {
+      system("pkg_add " . $package);
+    }
+  }
+
+  if (defined($data->{runcmd})) {
+    foreach my $runcmd (@{ $data->{runcmd} }) {
+      system("sh -c \"$runcmd\"");
+    }
+  }
 }
 
 sub cloud_init {


### PR DESCRIPTION
Add basic support for `packages` (using `pkg_add`) and `runcmd` (using shell) and update README file.
No additional checks are done.