### PR TITLE
cloud-init: add basic support for write_files

### DIFF
--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -84,6 +84,25 @@ sub apply_user_data {
       system("sh -c \"$runcmd\"");
     }
   }
+
+  if (defined($data->{write_files})) {
+    foreach my $item (@{ $data->{write_files} }) {
+      open my $fh, ">", $item->{path};
+      printf $fh "%s", $item->{content};
+      if (defined($item->{permissions})) {
+        my $perms = oct($item->{permissions});
+        chmod($perms, $fh);
+      }
+      if (defined($item->{owner})) {
+        my ($user_name, $group_name) = split(/\:/, $item->{owner});
+        my $uid = getpwnam $user_name;
+        my $gid = getgrnam $group_name;
+        chown $uid, $gid, $fh;
+      }
+      close $fh;
+      system("sh -c \"$item->{path}\"");
+    }
+  }
 }
 
 sub cloud_init {

--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -23,7 +23,8 @@
 
 use CPAN::Meta::YAML;
 use HTTP::Tiny;
-use File::Path qw(make_path);
+use File::Basename;
+use File::Path qw(make_path mkpath);
 use File::Temp qw(tempfile);
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError) ;
 
@@ -79,16 +80,11 @@ sub apply_user_data {
     }
   }
 
-  if (defined($data->{runcmd})) {
-    foreach my $runcmd (@{ $data->{runcmd} }) {
-      system("sh -c \"$runcmd\"");
-    }
-  }
-
   if (defined($data->{write_files})) {
     foreach my $item (@{ $data->{write_files} }) {
+      mkpath [dirname($item->{path})], 0, 0755;
       open my $fh, ">", $item->{path};
-      printf $fh "%s", $item->{content};
+      print $fh $item->{content};
       if (defined($item->{permissions})) {
         my $perms = oct($item->{permissions});
         chmod($perms, $fh);
@@ -100,7 +96,12 @@ sub apply_user_data {
         chown $uid, $gid, $fh;
       }
       close $fh;
-      system("sh -c \"$item->{path}\"");
+    }
+  }
+
+  if (defined($data->{runcmd})) {
+    foreach my $runcmd (@{ $data->{runcmd} }) {
+      system("sh -c \"$runcmd\"");
     }
   }
 }


### PR DESCRIPTION
This patch will handle the cloud-init `write_files` function.
Currently, only `path`, `permissions`, `owner` and `content` directives are supported.

Tested OK on OpenBSD 6.6/amd64