### PR TITLE
Use instance name as default hostname

### DIFF
--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -41,6 +41,15 @@ sub get_data {
   return $response->{content};
 }
 
+sub set_hostname {
+  my $fqdn = shift;
+
+  open my $fh, ">", "/etc/myname";
+  printf $fh "%s\n", $fqdn;
+  close $fh;
+  system("hostname " . $fqdn);
+}
+
 sub install_pubkeys {
   my $pubkeys = shift;
 
@@ -55,10 +64,7 @@ sub apply_user_data {
   my $data = shift;
 
   if (defined($data->{fqdn})) {
-    open my $fh, ">", "/etc/myname";
-    printf $fh "%s\n", $data->{fqdn};
-    close $fh;
-    system("hostname " . $data->{fqdn});
+    set_hostname $data->{fqdn};
   }
 
   if (defined($data->{manage_etc_hosts}) &&


### PR DESCRIPTION
This pull request changes `cloud-init.pl` so that `local-hostname` is used to construct a default hostname if no FQDN is supplied via user data.

For GNU/Linux instances on Exoscale, the Exoscale instance name is used as a hostname, while the default hostname for OpenBSD instances on Exoscale is `openbsd.example.com`, which makes identifying OpenBSD instances in instance pools rather hard.

This pull request sets the default hostname to `"${EXOSCALE_INSTANCE_NAME}.my.domain"`. ("my.domain" is the default domain used by the OpenBSD installer.)

Note: According to [myname(5)](https://man.openbsd.org/myname.5), hostnames set in `/etc/myname` have to be resolvable using DNS or `/etc/hosts`. Since the hostname currently defaults to `openbsd.example.com`, the present pull request does not introduce any new problems. The default hostname introduced in this pull request is not resolvable, but neither is `openbsd.example.com`.

Nevertheless, it would probably be best if `manage_etc_hosts` would default to `localhost` in order to make sure the hostname is resolvable. I'll open a separate issue for that.