### PR TITLE
Accept "localhost" as manage_etc_hosts value

### DIFF
--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -75,7 +75,8 @@ sub apply_user_data {
   }
 
   if (defined($data->{manage_etc_hosts}) &&
-      $data->{manage_etc_hosts} eq 'true') {
+      ($data->{manage_etc_hosts} eq 'true' ||
+       $data->{manage_etc_hosts} eq 'localhost')) {
     open my $fh, ">>", "/etc/hosts";
     my $fqdn = $data->{fqdn} // get_default_fqdn;
     my ($shortname) = split(/\./, $fqdn);

--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -80,7 +80,7 @@ sub apply_user_data {
     open my $fh, ">>", "/etc/hosts";
     my $fqdn = $data->{fqdn} // get_default_fqdn;
     my ($shortname) = split(/\./, $fqdn);
-    printf $fh "127.0.1.1 %s %s\n", $shortname, $fqdn;
+    printf $fh "127.0.1.1       %s %s\n", $shortname, $fqdn;
     close $fh;
   }
 


### PR DESCRIPTION
This pull request adds support for "localhost" as a `manage_etc_hosts` value.

See #11 and [cloud-init modules: Update Etc Hosts](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#update-etc-hosts) for details:

> If set to `true` or `template`, cloud-init will generate /etc/hosts using the template located in `/etc/cloud/templates/hosts.tmpl`. […]
> 
> If `manage_etc_hosts` is set to `localhost`, then cloud-init will not rewrite `/etc/hosts` entirely, but rather will ensure that a entry for the fqdn with a distribution dependent ip is present in `/etc/hosts` (i.e. `ping <hostname>` will ping `127.0.0.1` or `127.0.1.1` or other ip).