### PR TITLE
Enable manage_etc_hosts by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ as possible by default. The following actions are currently supported:
 
 - SSH [authorized_keys](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man8/sshd.8?query=sshd&sec=8) personalization if requested.
 - Persistent hostname personalization if requested.
-- Local host resolution personalization if requested.
+- Local host resolution personalization unless requested otherwise.
 - Optional custom script execution.
 - Packages installation (pkg_add) support.
 - Custom commands (runcmd) execution.

--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -125,6 +125,16 @@ sub apply_user_data {
   }
 }
 
+sub run_user_script {
+    my $data = shift;
+
+    my ($fh, $filename) = tempfile("/tmp/cloud-config-XXXXXX");
+    print $fh $data;
+    chmod(0700, $fh);
+    close $fh;
+    system("sh -c \"$filename && rm $filename\"");
+}
+
 sub cloud_init {
     my $host = METADATA_HOST;
 
@@ -143,12 +153,7 @@ sub cloud_init {
         } elsif ($data =~ /^#\!/) {
             set_hostname(get_default_fqdn);
             add_etc_hosts_entry(get_default_fqdn);
-
-            my ($fh, $filename) = tempfile("/tmp/cloud-config-XXXXXX");
-            print $fh $data;
-            chmod(0700, $fh);
-            close $fh;
-            system("sh -c \"$filename && rm $filename\"");
+            run_user_script($data);
         }
     } else {
         set_hostname(get_default_fqdn);

--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -57,6 +57,15 @@ sub set_hostname {
   system("hostname " . $fqdn);
 }
 
+sub add_etc_hosts_entry {
+    my $fqdn = shift;
+    my ($shortname) = split(/\./, $fqdn);
+
+    open my $fh, ">>", "/etc/hosts";
+    printf $fh "127.0.1.1       %s %s\n", $shortname, $fqdn;
+    close $fh;
+}
+
 sub install_pubkeys {
   my $pubkeys = shift;
 
@@ -77,11 +86,8 @@ sub apply_user_data {
   if (defined($data->{manage_etc_hosts}) &&
       ($data->{manage_etc_hosts} eq 'true' ||
        $data->{manage_etc_hosts} eq 'localhost')) {
-    open my $fh, ">>", "/etc/hosts";
     my $fqdn = $data->{fqdn} // get_default_fqdn;
-    my ($shortname) = split(/\./, $fqdn);
-    printf $fh "127.0.1.1       %s %s\n", $shortname, $fqdn;
-    close $fh;
+    add_etc_hosts_entry($fqdn);
   }
 
   if (defined($data->{ssh_authorized_keys})) {

--- a/cloud-init.pl
+++ b/cloud-init.pl
@@ -146,18 +146,16 @@ sub cloud_init {
     chomp($pubkeys);
     install_pubkeys $pubkeys;
 
-    if (defined($data)) {
-        if ($data =~ /^#cloud-config/) {
-            $data = CPAN::Meta::YAML->read_string($data)->[0];
-            apply_user_data $data;
-        } elsif ($data =~ /^#\!/) {
-            set_hostname(get_default_fqdn);
-            add_etc_hosts_entry(get_default_fqdn);
-            run_user_script($data);
-        }
+    if ($data =~ /^#cloud-config/) {
+        $data = CPAN::Meta::YAML->read_string($data)->[0];
+        apply_user_data($data);
     } else {
         set_hostname(get_default_fqdn);
         add_etc_hosts_entry(get_default_fqdn);
+
+        if ($data =~ /^#\!/) {
+            run_user_script($data);
+        }
     }
 }
 


### PR DESCRIPTION
As explained in issues #9 and #10, cloud-init.pl should default to adding a localhost entry for the chosen hostname to `/etc/hosts` in order to make sure it is resolvable.

See [myname(5)](https://man.openbsd.org/myname.5) for details:

> The name must be resolvable, either by matching a hostname specified in /etc/hosts (see hosts(5)) or through DNS (see resolv.conf(5)).

This pull request enables `manage_etc_hosts` by default. Users can disable the default behaviour by setting `manage_etc_hosts` to any value other than `true` or `localhost` in their user data.

Note: Commits bca5d54 and 8abc674 are not strictly speaking necessary for this to work, but IMO they significantly improve the readability of this patchset.